### PR TITLE
Getting a user's data by supplying a username

### DIFF
--- a/src/instajam.js
+++ b/src/instajam.js
@@ -213,11 +213,19 @@
       // Make a request to the API
       User.prototype.search.call(this, id, {}, function(result) {
 
-        // If the initial user search yields any
-        // results, then just return the first, but
+        // Go through the results and check for
+        // a perfect match, then query again with that user's ID
         // otherwise return nothing.
-        if (result.data && result.data.length === 1) {
-          result = result.data[0];
+        if (result.data) {    
+            var userIds = result.data;
+            result = false;
+
+            for (var i = 0; i < userIds.length; i++) {
+                if (userIds[i].username == id) {
+                    User.prototype.get(parseInt(userIds[i].id), callback);
+                    return;
+                }
+            }
         } else {
           result = false;
         }

--- a/src/instajam.js
+++ b/src/instajam.js
@@ -15,7 +15,7 @@
       throw new InstajamError("Client ID and Redirect URI are required.");
     }
 
-    // If the app is requesting additional 
+    // If the app is requesting additional p
     // scopes, build a string to append to
     // the auth URL.
     if (options.scope && typeof options.scope === 'object') {
@@ -221,8 +221,8 @@
             result = false;
 
             for (var i = 0; i < userIds.length; i++) {
-                if (userIds[i].username == id) {
-                    User.prototype.get(parseInt(userIds[i].id), callback);
+                if (userIds[i].username === id) {
+                    User.prototype.get(parseInt(userIds[i].id, 10), callback);
                     return;
                 }
             }


### PR DESCRIPTION
The User.prototype.get function is broken for queries with particular usernames.
For example, if try to get the user "abcd" and there are multiple usernames which begin with "abcd", the function will return 'false'.

Also, the data returned from this query is not the same as querying for a user with a supplied id.
After supplying an id, you get more data, such as the media and follower counts, which does not happen if you search for a user with a given name/string.

The function, as it is now, will go through the results and look for an exact match between the supplied username and the users in the result set and then query the API again with the user's id, after finding a match.